### PR TITLE
Can not found RNPStatusRestricted in iOS

### DIFF
--- a/ios/Permissions/RNPLocation.m
+++ b/ios/Permissions/RNPLocation.m
@@ -16,20 +16,24 @@
 @end
 
 @implementation RNPLocation
-
+    
 + (NSString *)getStatusForType:(NSString *)type {
-    int status = [CLLocationManager authorizationStatus];
-    switch (status) {
-        case kCLAuthorizationStatusAuthorizedAlways:
+    if ([CLLocationManager locationServicesEnabled]) {
+        int status = [CLLocationManager authorizationStatus];
+        switch (status) {
+            case kCLAuthorizationStatusAuthorizedAlways:
             return RNPStatusAuthorized;
-        case kCLAuthorizationStatusAuthorizedWhenInUse:
+            case kCLAuthorizationStatusAuthorizedWhenInUse:
             return [type isEqualToString:@"always"] ? RNPStatusDenied : RNPStatusAuthorized;
-        case kCLAuthorizationStatusDenied:
+            case kCLAuthorizationStatusDenied:
             return RNPStatusDenied;
-        case kCLAuthorizationStatusRestricted:
+            case kCLAuthorizationStatusRestricted:
             return RNPStatusRestricted;
-        default:
+            default:
             return RNPStatusUndetermined;
+        }
+    }else{
+        return RNPStatusRestricted;
     }
 }
 


### PR DESCRIPTION
When "Location Services" off from device we have to return the status "RNPStatusRestricted" but it returns "RNPStatusDenied".
So I added "location Services" check also for "RNPStatusRestricted".